### PR TITLE
Add columns

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,17 @@ plugins {
 	id 'maven-publish'
 }
 
+repositories {
+	maven {
+		name = "Cotton"
+		url = "https://server.bbkr.space/artifactory/libs-release"
+	}
+	maven {
+		name = "Curse"
+		url = "https://www.cursemaven.com"
+	}
+}
+
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
@@ -16,6 +27,13 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+	// LibCD
+	modImplementation "io.github.cottonmc:LibCD:${project.libcd_version}"
+	include "io.github.cottonmc:LibCD:${project.libcd_version}"
+
+	// Columns
+	modImplementation "curse.maven:columns-385230:3107117"
 
 	// ARRP is a fabric api for creating resources and assets during runtime
 	//modImplementation group: 'net.devtech', name: 'arrp', version: '0.3.2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@ archives_base_name = breadcrumbs
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 fabric_version=0.29.3+1.16
+libcd_version=3.0.3+1.16.3

--- a/src/main/java/com/github/evoslab/breadcrumbs/Breadcrumbs.java
+++ b/src/main/java/com/github/evoslab/breadcrumbs/Breadcrumbs.java
@@ -1,8 +1,10 @@
 package com.github.evoslab.breadcrumbs;
 
 import com.github.evoslab.breadcrumbs.registry.BreadcrumbsBlocks;
+import com.github.evoslab.breadcrumbs.registry.BreadcrumbsColumnBlocks;
 import com.github.evoslab.breadcrumbs.registry.BreadcrumbsItems;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -18,6 +20,10 @@ public class Breadcrumbs implements ModInitializer {
 		new BreadcrumbsBlocks();
 		BreadcrumbsBlocks.RegisterBreadcrumbsBlocks();
 		BreadcrumbsItems.RegisterBreadcrumbsItems();
+
+		if (FabricLoader.getInstance().isModLoaded("columns")) {
+			BreadcrumbsColumnBlocks.RegisterBreadcrumbsColumnBlocks();
+		}
 	}
 
 	public static Identifier id(String name) {

--- a/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
+++ b/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
@@ -23,6 +23,7 @@ public class BreadcrumbsColumnBlocks {
         RegisterBreadcrumbsColumnBlocks("honey_bread_brick_column", BreadcrumbsBlocks.HONEY_BREAD_BRICKS);
 
         RegisterBreadcrumbsColumnBlocks("pumpkin_bread_column", BreadcrumbsBlocks.PUMPKIN_BREAD_BLOCK);
+        RegisterBreadcrumbsColumnBlocks("polished_pumpkin_bread_column", BreadcrumbsBlocks.POLISHED_PUMPKIN_BREAD_BLOCK);
     }
 
     private static void RegisterBreadcrumbsColumnBlocks(String path, Block base) {

--- a/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
+++ b/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
@@ -17,6 +17,8 @@ public class BreadcrumbsColumnBlocks {
         RegisterBreadcrumbsColumnBlocks("bread_column", BreadcrumbsBlocks.BREAD_BLOCK);
         RegisterBreadcrumbsColumnBlocks("polished_bread_column", BreadcrumbsBlocks.POLISHED_BREAD_BLOCK);
         RegisterBreadcrumbsColumnBlocks("bread_brick_column", BreadcrumbsBlocks.BREAD_BRICKS);
+
+        RegisterBreadcrumbsColumnBlocks("honey_bread_column", BreadcrumbsBlocks.HONEY_BREAD_BLOCK);
     }
 
     private static void RegisterBreadcrumbsColumnBlocks(String path, Block base) {

--- a/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
+++ b/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
@@ -16,6 +16,7 @@ public class BreadcrumbsColumnBlocks {
     public static void RegisterBreadcrumbsColumnBlocks() {
         RegisterBreadcrumbsColumnBlocks("bread_column", BreadcrumbsBlocks.BREAD_BLOCK);
         RegisterBreadcrumbsColumnBlocks("polished_bread_column", BreadcrumbsBlocks.POLISHED_BREAD_BLOCK);
+        RegisterBreadcrumbsColumnBlocks("bread_brick_column", BreadcrumbsBlocks.BREAD_BRICKS);
     }
 
     private static void RegisterBreadcrumbsColumnBlocks(String path, Block base) {

--- a/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
+++ b/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
@@ -1,0 +1,29 @@
+package com.github.evoslab.breadcrumbs.registry;
+
+import com.github.evoslab.breadcrumbs.Breadcrumbs;
+
+import io.github.haykam821.columns.block.ColumnBlock;
+import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+import net.minecraft.block.Block;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+public class BreadcrumbsColumnBlocks {
+    
+    public static void RegisterBreadcrumbsColumnBlocks() {
+        RegisterBreadcrumbsColumnBlocks("bread_column", BreadcrumbsBlocks.BREAD_BLOCK);
+    }
+
+    private static void RegisterBreadcrumbsColumnBlocks(String path, Block base) {
+        Identifier id = new Identifier(Breadcrumbs.MODID, path);
+
+        Block block = new ColumnBlock(FabricBlockSettings.copy(base));
+        Registry.register(Registry.BLOCK, id, block);
+
+        Registry.register(Registry.ITEM, id, new BlockItem(block, new Item.Settings().group(ItemGroup.DECORATIONS)));
+    }
+
+}

--- a/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
+++ b/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
@@ -15,6 +15,7 @@ public class BreadcrumbsColumnBlocks {
     
     public static void RegisterBreadcrumbsColumnBlocks() {
         RegisterBreadcrumbsColumnBlocks("bread_column", BreadcrumbsBlocks.BREAD_BLOCK);
+        RegisterBreadcrumbsColumnBlocks("polished_bread_column", BreadcrumbsBlocks.POLISHED_BREAD_BLOCK);
     }
 
     private static void RegisterBreadcrumbsColumnBlocks(String path, Block base) {

--- a/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
+++ b/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
@@ -20,6 +20,7 @@ public class BreadcrumbsColumnBlocks {
 
         RegisterBreadcrumbsColumnBlocks("honey_bread_column", BreadcrumbsBlocks.HONEY_BREAD_BLOCK);
         RegisterBreadcrumbsColumnBlocks("polished_honey_bread_column", BreadcrumbsBlocks.POLISHED_HONEY_BREAD_BLOCK);
+        RegisterBreadcrumbsColumnBlocks("honey_bread_brick_column", BreadcrumbsBlocks.HONEY_BREAD_BRICKS);
     }
 
     private static void RegisterBreadcrumbsColumnBlocks(String path, Block base) {

--- a/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
+++ b/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
@@ -21,6 +21,8 @@ public class BreadcrumbsColumnBlocks {
         RegisterBreadcrumbsColumnBlocks("honey_bread_column", BreadcrumbsBlocks.HONEY_BREAD_BLOCK);
         RegisterBreadcrumbsColumnBlocks("polished_honey_bread_column", BreadcrumbsBlocks.POLISHED_HONEY_BREAD_BLOCK);
         RegisterBreadcrumbsColumnBlocks("honey_bread_brick_column", BreadcrumbsBlocks.HONEY_BREAD_BRICKS);
+
+        RegisterBreadcrumbsColumnBlocks("pumpkin_bread_column", BreadcrumbsBlocks.PUMPKIN_BREAD_BLOCK);
     }
 
     private static void RegisterBreadcrumbsColumnBlocks(String path, Block base) {

--- a/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
+++ b/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
@@ -24,6 +24,7 @@ public class BreadcrumbsColumnBlocks {
 
         RegisterBreadcrumbsColumnBlocks("pumpkin_bread_column", BreadcrumbsBlocks.PUMPKIN_BREAD_BLOCK);
         RegisterBreadcrumbsColumnBlocks("polished_pumpkin_bread_column", BreadcrumbsBlocks.POLISHED_PUMPKIN_BREAD_BLOCK);
+        RegisterBreadcrumbsColumnBlocks("pumpkin_bread_brick_column", BreadcrumbsBlocks.PUMPKIN_BREAD_BRICKS);
     }
 
     private static void RegisterBreadcrumbsColumnBlocks(String path, Block base) {

--- a/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
+++ b/src/main/java/com/github/evoslab/breadcrumbs/registry/BreadcrumbsColumnBlocks.java
@@ -19,6 +19,7 @@ public class BreadcrumbsColumnBlocks {
         RegisterBreadcrumbsColumnBlocks("bread_brick_column", BreadcrumbsBlocks.BREAD_BRICKS);
 
         RegisterBreadcrumbsColumnBlocks("honey_bread_column", BreadcrumbsBlocks.HONEY_BREAD_BLOCK);
+        RegisterBreadcrumbsColumnBlocks("polished_honey_bread_column", BreadcrumbsBlocks.POLISHED_HONEY_BREAD_BLOCK);
     }
 
     private static void RegisterBreadcrumbsColumnBlocks(String path, Block base) {

--- a/src/main/resources/assets/breadcrumbs/blockstates/bread_brick_column.json
+++ b/src/main/resources/assets/breadcrumbs/blockstates/bread_brick_column.json
@@ -1,0 +1,27 @@
+{
+    "multipart": [
+        {
+            "apply": {
+                "model": "breadcrumbs:block/bread_brick_column_center"
+            }
+        },
+        {
+            "when": {
+                "down": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/bread_brick_column_end"
+            }
+        },
+        {
+            "when": {
+                "up": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/bread_brick_column_end",
+                "x": 180,
+                "uvlock": true
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/breadcrumbs/blockstates/bread_column.json
+++ b/src/main/resources/assets/breadcrumbs/blockstates/bread_column.json
@@ -1,0 +1,27 @@
+{
+    "multipart": [
+        {
+            "apply": {
+                "model": "breadcrumbs:block/bread_column_center"
+            }
+        },
+        {
+            "when": {
+                "down": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/bread_column_end"
+            }
+        },
+        {
+            "when": {
+                "up": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/bread_column_end",
+                "x": 180,
+                "uvlock": true
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/breadcrumbs/blockstates/honey_bread_brick_column.json
+++ b/src/main/resources/assets/breadcrumbs/blockstates/honey_bread_brick_column.json
@@ -1,0 +1,27 @@
+{
+    "multipart": [
+        {
+            "apply": {
+                "model": "breadcrumbs:block/honey_bread_brick_column_center"
+            }
+        },
+        {
+            "when": {
+                "down": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/honey_bread_brick_column_end"
+            }
+        },
+        {
+            "when": {
+                "up": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/honey_bread_brick_column_end",
+                "x": 180,
+                "uvlock": true
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/breadcrumbs/blockstates/honey_bread_column.json
+++ b/src/main/resources/assets/breadcrumbs/blockstates/honey_bread_column.json
@@ -1,0 +1,27 @@
+{
+    "multipart": [
+        {
+            "apply": {
+                "model": "breadcrumbs:block/honey_bread_column_center"
+            }
+        },
+        {
+            "when": {
+                "down": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/honey_bread_column_end"
+            }
+        },
+        {
+            "when": {
+                "up": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/honey_bread_column_end",
+                "x": 180,
+                "uvlock": true
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/breadcrumbs/blockstates/polished_bread_column.json
+++ b/src/main/resources/assets/breadcrumbs/blockstates/polished_bread_column.json
@@ -1,0 +1,27 @@
+{
+    "multipart": [
+        {
+            "apply": {
+                "model": "breadcrumbs:block/polished_bread_column_center"
+            }
+        },
+        {
+            "when": {
+                "down": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/polished_bread_column_end"
+            }
+        },
+        {
+            "when": {
+                "up": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/polished_bread_column_end",
+                "x": 180,
+                "uvlock": true
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/breadcrumbs/blockstates/polished_honey_bread_column.json
+++ b/src/main/resources/assets/breadcrumbs/blockstates/polished_honey_bread_column.json
@@ -1,0 +1,27 @@
+{
+    "multipart": [
+        {
+            "apply": {
+                "model": "breadcrumbs:block/polished_honey_bread_column_center"
+            }
+        },
+        {
+            "when": {
+                "down": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/polished_honey_bread_column_end"
+            }
+        },
+        {
+            "when": {
+                "up": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/polished_honey_bread_column_end",
+                "x": 180,
+                "uvlock": true
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/breadcrumbs/blockstates/polished_pumpkin_bread_column.json
+++ b/src/main/resources/assets/breadcrumbs/blockstates/polished_pumpkin_bread_column.json
@@ -1,0 +1,27 @@
+{
+    "multipart": [
+        {
+            "apply": {
+                "model": "breadcrumbs:block/polished_pumpkin_bread_column_center"
+            }
+        },
+        {
+            "when": {
+                "down": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/polished_pumpkin_bread_column_end"
+            }
+        },
+        {
+            "when": {
+                "up": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/polished_pumpkin_bread_column_end",
+                "x": 180,
+                "uvlock": true
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/breadcrumbs/blockstates/pumpkin_bread_brick_column.json
+++ b/src/main/resources/assets/breadcrumbs/blockstates/pumpkin_bread_brick_column.json
@@ -1,0 +1,27 @@
+{
+    "multipart": [
+        {
+            "apply": {
+                "model": "breadcrumbs:block/pumpkin_bread_brick_column_center"
+            }
+        },
+        {
+            "when": {
+                "down": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/pumpkin_bread_brick_column_end"
+            }
+        },
+        {
+            "when": {
+                "up": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/pumpkin_bread_brick_column_end",
+                "x": 180,
+                "uvlock": true
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/breadcrumbs/blockstates/pumpkin_bread_column.json
+++ b/src/main/resources/assets/breadcrumbs/blockstates/pumpkin_bread_column.json
@@ -1,0 +1,27 @@
+{
+    "multipart": [
+        {
+            "apply": {
+                "model": "breadcrumbs:block/pumpkin_bread_column_center"
+            }
+        },
+        {
+            "when": {
+                "down": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/pumpkin_bread_column_end"
+            }
+        },
+        {
+            "when": {
+                "up": true
+            },
+            "apply": {
+                "model": "breadcrumbs:block/pumpkin_bread_column_end",
+                "x": 180,
+                "uvlock": true
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/breadcrumbs/lang/en_us.json
+++ b/src/main/resources/assets/breadcrumbs/lang/en_us.json
@@ -59,6 +59,7 @@
   "block.breadcrumbs.pumpkin_bread_brick_slab": "Pumpkin Bread Brick Slab",
   "block.breadcrumbs.pumpkin_bread_brick_stairs": "Pumpkin Bread Brick Stairs",
   "block.breadcrumbs.pumpkin_bread_brick_wall": "Pumpkin Bread Brick Wall",
+  "block.breadcrumbs.pumpkin_bread_brick_column": "Pumpkin Bread Brick Column",
 
   "block.breadcrumbs.pumpkin_bread_pavement": "Pumpkin Bread Pavement",
   "block.breadcrumbs.pumpkin_bread_pillar": "Pumpkin Bread Pillar",

--- a/src/main/resources/assets/breadcrumbs/lang/en_us.json
+++ b/src/main/resources/assets/breadcrumbs/lang/en_us.json
@@ -15,6 +15,7 @@
   "block.breadcrumbs.bread_brick_slab": "Bread Brick Slab",
   "block.breadcrumbs.bread_brick_stairs": "Bread Brick Stairs",
   "block.breadcrumbs.bread_brick_wall": "Bread Brick Wall",
+  "block.breadcrumbs.bread_brick_column": "Bread Brick Column",
 
   "block.breadcrumbs.bread_pavement": "Bread Pavement",
   "block.breadcrumbs.bread_pillar": "Bread Pillar",

--- a/src/main/resources/assets/breadcrumbs/lang/en_us.json
+++ b/src/main/resources/assets/breadcrumbs/lang/en_us.json
@@ -3,6 +3,7 @@
   "block.breadcrumbs.bread_slab": "Bread Slab",
   "block.breadcrumbs.bread_stairs": "Bread Stairs",
   "block.breadcrumbs.bread_wall": "Bread Wall",
+  "block.breadcrumbs.bread_column": "Bread Column",
 
   "block.breadcrumbs.polished_bread_block": "Polished Bread Block",
   "block.breadcrumbs.polished_bread_slab": "Polished Bread Slab",

--- a/src/main/resources/assets/breadcrumbs/lang/en_us.json
+++ b/src/main/resources/assets/breadcrumbs/lang/en_us.json
@@ -47,6 +47,7 @@
   "block.breadcrumbs.pumpkin_bread_slab": "Pumpkin Bread Slab",
   "block.breadcrumbs.pumpkin_bread_stairs": "Pumpkin Bread Stairs",
   "block.breadcrumbs.pumpkin_bread_wall": "Pumpkin Bread Wall",
+  "block.breadcrumbs.pumpkin_bread_column": "Pumpkin Bread Column",
 
   "block.breadcrumbs.polished_pumpkin_bread_block": "Polished Pumpkin Bread Block",
   "block.breadcrumbs.polished_pumpkin_bread_slab": "Polished Pumpkin Bread Slab",

--- a/src/main/resources/assets/breadcrumbs/lang/en_us.json
+++ b/src/main/resources/assets/breadcrumbs/lang/en_us.json
@@ -31,6 +31,7 @@
   "block.breadcrumbs.polished_honey_bread_slab": "Polished Honey Bread Slab",
   "block.breadcrumbs.polished_honey_bread_stairs": "Polished Honey Bread Stairs",
   "block.breadcrumbs.polished_honey_bread_wall": "Polished Honey Bread Wall",
+  "block.breadcrumbs.polished_honey_bread_column": "Polished Honey Bread Column",
 
   "block.breadcrumbs.honey_bread_bricks": "Honey Bread Bricks",
   "block.breadcrumbs.honey_bread_brick_slab": "Honey Bread Brick Slab",

--- a/src/main/resources/assets/breadcrumbs/lang/en_us.json
+++ b/src/main/resources/assets/breadcrumbs/lang/en_us.json
@@ -53,6 +53,7 @@
   "block.breadcrumbs.polished_pumpkin_bread_slab": "Polished Pumpkin Bread Slab",
   "block.breadcrumbs.polished_pumpkin_bread_stairs": "Polished Pumpkin Bread Stairs",
   "block.breadcrumbs.polished_pumpkin_bread_wall": "Polished Pumpkin Bread Wall",
+  "block.breadcrumbs.polished_pumpkin_bread_column": "Polished Pumpkin Bread Column",
 
   "block.breadcrumbs.pumpkin_bread_bricks": "Pumpkin Bread Bricks",
   "block.breadcrumbs.pumpkin_bread_brick_slab": "Pumpkin Bread Brick Slab",

--- a/src/main/resources/assets/breadcrumbs/lang/en_us.json
+++ b/src/main/resources/assets/breadcrumbs/lang/en_us.json
@@ -9,6 +9,7 @@
   "block.breadcrumbs.polished_bread_slab": "Polished Bread Slab",
   "block.breadcrumbs.polished_bread_stairs": "Polished Bread Stairs",
   "block.breadcrumbs.polished_bread_wall": "Polished Bread Wall",
+  "block.breadcrumbs.polished_bread_column": "Polished Bread Column",
 
   "block.breadcrumbs.bread_bricks": "Bread Bricks",
   "block.breadcrumbs.bread_brick_slab": "Bread Brick Slab",

--- a/src/main/resources/assets/breadcrumbs/lang/en_us.json
+++ b/src/main/resources/assets/breadcrumbs/lang/en_us.json
@@ -37,6 +37,7 @@
   "block.breadcrumbs.honey_bread_brick_slab": "Honey Bread Brick Slab",
   "block.breadcrumbs.honey_bread_brick_stairs": "Honey Bread Brick Stairs",
   "block.breadcrumbs.honey_bread_brick_wall": "Honey Bread Brick Wall",
+  "block.breadcrumbs.honey_bread_brick_column": "Honey Bread Brick Column",
 
   "block.breadcrumbs.honey_bread_pavement": "Honey Bread Pavement",
   "block.breadcrumbs.honey_bread_pillar": "Honey Bread Pillar",

--- a/src/main/resources/assets/breadcrumbs/lang/en_us.json
+++ b/src/main/resources/assets/breadcrumbs/lang/en_us.json
@@ -25,6 +25,7 @@
   "block.breadcrumbs.honey_bread_slab": "Honey Bread Slab",
   "block.breadcrumbs.honey_bread_stairs": "Honey Bread Stairs",
   "block.breadcrumbs.honey_bread_wall": "Honey Bread Wall",
+  "block.breadcrumbs.honey_bread_column": "Honey Bread Column",
 
   "block.breadcrumbs.polished_honey_bread_block": "Polished Honey Bread Block",
   "block.breadcrumbs.polished_honey_bread_slab": "Polished Honey Bread Slab",

--- a/src/main/resources/assets/breadcrumbs/models/block/bread_brick_column_center.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/bread_brick_column_center.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_center",
+    "textures": {
+        "all": "breadcrumbs:block/bread_bricks"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/bread_brick_column_end.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/bread_brick_column_end.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_end",
+    "textures": {
+        "all": "breadcrumbs:block/bread_bricks"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/bread_brick_column_inventory.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/bread_brick_column_inventory.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_inventory",
+    "textures": {
+        "all": "breadcrumbs:block/bread_bricks"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/bread_column_center.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/bread_column_center.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_center",
+    "textures": {
+        "all": "breadcrumbs:block/bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/bread_column_end.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/bread_column_end.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_end",
+    "textures": {
+        "all": "breadcrumbs:block/bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/bread_column_inventory.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/bread_column_inventory.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_inventory",
+    "textures": {
+        "all": "breadcrumbs:block/bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/honey_bread_brick_column_center.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/honey_bread_brick_column_center.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_center",
+    "textures": {
+        "all": "breadcrumbs:block/honey_bread_bricks"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/honey_bread_brick_column_end.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/honey_bread_brick_column_end.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_end",
+    "textures": {
+        "all": "breadcrumbs:block/honey_bread_bricks"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/honey_bread_brick_column_inventory.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/honey_bread_brick_column_inventory.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_inventory",
+    "textures": {
+        "all": "breadcrumbs:block/honey_bread_bricks"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/honey_bread_column_center.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/honey_bread_column_center.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_center",
+    "textures": {
+        "all": "breadcrumbs:block/honey_bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/honey_bread_column_end.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/honey_bread_column_end.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_end",
+    "textures": {
+        "all": "breadcrumbs:block/honey_bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/honey_bread_column_inventory.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/honey_bread_column_inventory.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_inventory",
+    "textures": {
+        "all": "breadcrumbs:block/honey_bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/polished_bread_column_center.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/polished_bread_column_center.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_center",
+    "textures": {
+        "all": "breadcrumbs:block/polished_bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/polished_bread_column_end.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/polished_bread_column_end.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_end",
+    "textures": {
+        "all": "breadcrumbs:block/polished_bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/polished_bread_column_inventory.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/polished_bread_column_inventory.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_inventory",
+    "textures": {
+        "all": "breadcrumbs:block/polished_bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/polished_honey_bread_column_center.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/polished_honey_bread_column_center.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_center",
+    "textures": {
+        "all": "breadcrumbs:block/polished_honey_bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/polished_honey_bread_column_end.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/polished_honey_bread_column_end.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_end",
+    "textures": {
+        "all": "breadcrumbs:block/polished_honey_bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/polished_honey_bread_column_inventory.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/polished_honey_bread_column_inventory.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_inventory",
+    "textures": {
+        "all": "breadcrumbs:block/polished_honey_bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/polished_pumpkin_bread_column_center.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/polished_pumpkin_bread_column_center.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_center",
+    "textures": {
+        "all": "breadcrumbs:block/polished_pumpkin_bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/polished_pumpkin_bread_column_end.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/polished_pumpkin_bread_column_end.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_end",
+    "textures": {
+        "all": "breadcrumbs:block/polished_pumpkin_bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/polished_pumpkin_bread_column_inventory.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/polished_pumpkin_bread_column_inventory.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_inventory",
+    "textures": {
+        "all": "breadcrumbs:block/polished_pumpkin_bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/pumpkin_bread_brick_column_center.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/pumpkin_bread_brick_column_center.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_center",
+    "textures": {
+        "all": "breadcrumbs:block/pumpkin_bread_bricks"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/pumpkin_bread_brick_column_end.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/pumpkin_bread_brick_column_end.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_end",
+    "textures": {
+        "all": "breadcrumbs:block/pumpkin_bread_bricks"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/pumpkin_bread_brick_column_inventory.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/pumpkin_bread_brick_column_inventory.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_inventory",
+    "textures": {
+        "all": "breadcrumbs:block/pumpkin_bread_bricks"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/pumpkin_bread_column_center.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/pumpkin_bread_column_center.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_center",
+    "textures": {
+        "all": "breadcrumbs:block/pumpkin_bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/pumpkin_bread_column_end.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/pumpkin_bread_column_end.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_end",
+    "textures": {
+        "all": "breadcrumbs:block/pumpkin_bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/block/pumpkin_bread_column_inventory.json
+++ b/src/main/resources/assets/breadcrumbs/models/block/pumpkin_bread_column_inventory.json
@@ -1,0 +1,6 @@
+{
+    "parent": "columns:block/column_inventory",
+    "textures": {
+        "all": "breadcrumbs:block/pumpkin_bread_block"
+    }
+}

--- a/src/main/resources/assets/breadcrumbs/models/item/bread_brick_column.json
+++ b/src/main/resources/assets/breadcrumbs/models/item/bread_brick_column.json
@@ -1,0 +1,3 @@
+{
+    "parent": "breadcrumbs:block/bread_brick_column_inventory"
+}

--- a/src/main/resources/assets/breadcrumbs/models/item/bread_column.json
+++ b/src/main/resources/assets/breadcrumbs/models/item/bread_column.json
@@ -1,0 +1,3 @@
+{
+    "parent": "breadcrumbs:block/bread_column_inventory"
+}

--- a/src/main/resources/assets/breadcrumbs/models/item/honey_bread_brick_column.json
+++ b/src/main/resources/assets/breadcrumbs/models/item/honey_bread_brick_column.json
@@ -1,0 +1,3 @@
+{
+    "parent": "breadcrumbs:block/honey_bread_brick_column_inventory"
+}

--- a/src/main/resources/assets/breadcrumbs/models/item/honey_bread_column.json
+++ b/src/main/resources/assets/breadcrumbs/models/item/honey_bread_column.json
@@ -1,0 +1,3 @@
+{
+    "parent": "breadcrumbs:block/honey_bread_column_inventory"
+}

--- a/src/main/resources/assets/breadcrumbs/models/item/polished_bread_column.json
+++ b/src/main/resources/assets/breadcrumbs/models/item/polished_bread_column.json
@@ -1,0 +1,3 @@
+{
+    "parent": "breadcrumbs:block/polished_bread_column_inventory"
+}

--- a/src/main/resources/assets/breadcrumbs/models/item/polished_honey_bread_column.json
+++ b/src/main/resources/assets/breadcrumbs/models/item/polished_honey_bread_column.json
@@ -1,0 +1,3 @@
+{
+    "parent": "breadcrumbs:block/polished_honey_bread_column_inventory"
+}

--- a/src/main/resources/assets/breadcrumbs/models/item/polished_pumpkin_bread_column.json
+++ b/src/main/resources/assets/breadcrumbs/models/item/polished_pumpkin_bread_column.json
@@ -1,0 +1,3 @@
+{
+    "parent": "breadcrumbs:block/polished_pumpkin_bread_column_inventory"
+}

--- a/src/main/resources/assets/breadcrumbs/models/item/pumpkin_bread_brick_column.json
+++ b/src/main/resources/assets/breadcrumbs/models/item/pumpkin_bread_brick_column.json
@@ -1,0 +1,3 @@
+{
+    "parent": "breadcrumbs:block/pumpkin_bread_brick_column_inventory"
+}

--- a/src/main/resources/assets/breadcrumbs/models/item/pumpkin_bread_column.json
+++ b/src/main/resources/assets/breadcrumbs/models/item/pumpkin_bread_column.json
@@ -1,0 +1,3 @@
+{
+    "parent": "breadcrumbs:block/pumpkin_bread_column_inventory"
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/bread_brick_column.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/bread_brick_column.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:bread_brick_column"
+        ]
+    },
+    "criteria": {
+        "has_bread_bricks": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:bread_bricks"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:bread_brick_column"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_bread_bricks",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/bread_brick_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/bread_brick_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/bread_brick_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/bread_brick_column_from_stonecutting.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:bread_brick_column_from_stonecutting"
+        ]
+    },
+    "criteria": {
+        "has_bread_bricks": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:bread_bricks"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:bread_brick_column_from_stonecutting"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_bread_bricks",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/bread_brick_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/bread_brick_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/bread_column.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/bread_column.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:bread_column"
+        ]
+    },
+    "criteria": {
+        "has_breadcrumbs:bread_block": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:bread_block"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:bread_column"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_breadcrumbs:bread_block",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/bread_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/bread_column_from_stonecutting.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:bread_column_from_stonecutting"
+        ]
+    },
+    "criteria": {
+        "has_breadcrumbs:bread_block": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:bread_block"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:bread_column_from_stonecutting"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_breadcrumbs:bread_block",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/bread_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/bread_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_brick_column.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_brick_column.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:honey_bread_brick_column"
+        ]
+    },
+    "criteria": {
+        "has_honey_bread_bricks": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:honey_bread_bricks"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:honey_bread_brick_column"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_honey_bread_bricks",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_brick_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_brick_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_brick_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_brick_column_from_stonecutting.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:honey_bread_brick_column_from_stonecutting"
+        ]
+    },
+    "criteria": {
+        "has_honey_bread_bricks": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:honey_bread_bricks"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:honey_bread_brick_column_from_stonecutting"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_honey_bread_bricks",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_brick_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_brick_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_column.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_column.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:honey_bread_column"
+        ]
+    },
+    "criteria": {
+        "has_breadcrumbs:honey_bread_block": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:honey_bread_block"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:honey_bread_column"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_breadcrumbs:honey_bread_block",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_column_from_stonecutting.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:honey_bread_column_from_stonecutting"
+        ]
+    },
+    "criteria": {
+        "has_breadcrumbs:honey_bread_block": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:honey_bread_block"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:honey_bread_column_from_stonecutting"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_breadcrumbs:honey_bread_block",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/honey_bread_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/polished_bread_column.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/polished_bread_column.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:polished_bread_column"
+        ]
+    },
+    "criteria": {
+        "has_breadcrumbs:polished_bread_block": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:polished_bread_block"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:polished_bread_column"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_breadcrumbs:polished_bread_block",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/polished_bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/polished_bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/polished_bread_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/polished_bread_column_from_stonecutting.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:polished_bread_column_from_stonecutting"
+        ]
+    },
+    "criteria": {
+        "has_breadcrumbs:polished_bread_block": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:polished_bread_block"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:polished_bread_column_from_stonecutting"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_breadcrumbs:polished_bread_block",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/polished_bread_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/polished_bread_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/polished_honey_bread_column.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/polished_honey_bread_column.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:polished_honey_bread_column"
+        ]
+    },
+    "criteria": {
+        "has_breadcrumbs:polished_honey_bread_block": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:polished_honey_bread_block"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:polished_honey_bread_column"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_breadcrumbs:polished_honey_bread_block",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/polished_honey_bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/polished_honey_bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/polished_honey_bread_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/polished_honey_bread_column_from_stonecutting.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:polished_honey_bread_column_from_stonecutting"
+        ]
+    },
+    "criteria": {
+        "has_breadcrumbs:polished_honey_bread_block": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:polished_honey_bread_block"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:polished_honey_bread_column_from_stonecutting"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_breadcrumbs:polished_honey_bread_block",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/polished_honey_bread_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/polished_honey_bread_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/polished_pumpkin_bread_column.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/polished_pumpkin_bread_column.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:polished_pumpkin_bread_column"
+        ]
+    },
+    "criteria": {
+        "has_breadcrumbs:polished_pumpkin_bread_block": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:polished_pumpkin_bread_block"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:polished_pumpkin_bread_column"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_breadcrumbs:polished_pumpkin_bread_block",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/polished_pumpkin_bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/polished_pumpkin_bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/polished_pumpkin_bread_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/polished_pumpkin_bread_column_from_stonecutting.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:polished_pumpkin_bread_column_from_stonecutting"
+        ]
+    },
+    "criteria": {
+        "has_breadcrumbs:polished_pumpkin_bread_block": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:polished_pumpkin_bread_block"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:polished_pumpkin_bread_column_from_stonecutting"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_breadcrumbs:polished_pumpkin_bread_block",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/polished_pumpkin_bread_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/polished_pumpkin_bread_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_brick_column.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_brick_column.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:pumpkin_bread_brick_column"
+        ]
+    },
+    "criteria": {
+        "has_pumpkin_bread_bricks": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:pumpkin_bread_bricks"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:pumpkin_bread_brick_column"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_pumpkin_bread_bricks",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_brick_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_brick_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_brick_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_brick_column_from_stonecutting.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:pumpkin_bread_brick_column_from_stonecutting"
+        ]
+    },
+    "criteria": {
+        "has_pumpkin_bread_bricks": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:pumpkin_bread_bricks"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:pumpkin_bread_brick_column_from_stonecutting"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_pumpkin_bread_bricks",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_brick_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_brick_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_column.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_column.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:pumpkin_bread_column"
+        ]
+    },
+    "criteria": {
+        "has_breadcrumbs:pumpkin_bread_block": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:pumpkin_bread_block"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:pumpkin_bread_column"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_breadcrumbs:pumpkin_bread_block",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_column_from_stonecutting.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "breadcrumbs:pumpkin_bread_column_from_stonecutting"
+        ]
+    },
+    "criteria": {
+        "has_breadcrumbs:pumpkin_bread_block": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "breadcrumbs:pumpkin_bread_block"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "breadcrumbs:pumpkin_bread_column_from_stonecutting"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_breadcrumbs:pumpkin_bread_block",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/advancements/recipes/pumpkin_bread_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/bread_brick_column.json
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/bread_brick_column.json
@@ -1,0 +1,19 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "breadcrumbs:bread_brick_column"
+                }
+            ],
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/bread_brick_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/bread_brick_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/bread_column.json
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/bread_column.json
@@ -1,0 +1,19 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "breadcrumbs:bread_column"
+                }
+            ],
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/honey_bread_brick_column.json
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/honey_bread_brick_column.json
@@ -1,0 +1,19 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "breadcrumbs:honey_bread_brick_column"
+                }
+            ],
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/honey_bread_brick_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/honey_bread_brick_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/honey_bread_column.json
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/honey_bread_column.json
@@ -1,0 +1,19 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "breadcrumbs:honey_bread_column"
+                }
+            ],
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/honey_bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/honey_bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/polished_bread_column.json
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/polished_bread_column.json
@@ -1,0 +1,19 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "breadcrumbs:polished_bread_column"
+                }
+            ],
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/polished_bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/polished_bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/polished_honey_bread_column.json
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/polished_honey_bread_column.json
@@ -1,0 +1,19 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "breadcrumbs:polished_honey_bread_column"
+                }
+            ],
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/polished_honey_bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/polished_honey_bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/polished_pumpkin_bread_column.json
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/polished_pumpkin_bread_column.json
@@ -1,0 +1,19 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "breadcrumbs:polished_pumpkin_bread_column"
+                }
+            ],
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/polished_pumpkin_bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/polished_pumpkin_bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/pumpkin_bread_brick_column.json
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/pumpkin_bread_brick_column.json
@@ -1,0 +1,19 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "breadcrumbs:pumpkin_bread_brick_column"
+                }
+            ],
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/pumpkin_bread_brick_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/pumpkin_bread_brick_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/pumpkin_bread_column.json
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/pumpkin_bread_column.json
@@ -1,0 +1,19 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "breadcrumbs:pumpkin_bread_column"
+                }
+            ],
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/loot_tables/blocks/pumpkin_bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/loot_tables/blocks/pumpkin_bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/bread_brick_column.json
+++ b/src/main/resources/data/breadcrumbs/recipes/bread_brick_column.json
@@ -1,0 +1,17 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "bbb",
+        " b ",
+        "bbb"
+    ],
+    "key": {
+        "b": {
+            "item": "breadcrumbs:bread_bricks"
+        }
+    },
+    "result": {
+        "item": "breadcrumbs:bread_brick_column",
+        "count": 6
+    }
+}

--- a/src/main/resources/data/breadcrumbs/recipes/bread_brick_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/bread_brick_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/bread_brick_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/recipes/bread_brick_column_from_stonecutting.json
@@ -1,0 +1,8 @@
+{
+    "type": "minecraft:stonecutting",
+    "ingredient": {
+        "item": "breadcrumbs:bread_bricks"
+    },
+    "result": "breadcrumbs:bread_brick_column",
+    "count": 1
+}

--- a/src/main/resources/data/breadcrumbs/recipes/bread_brick_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/bread_brick_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/bread_column.json
+++ b/src/main/resources/data/breadcrumbs/recipes/bread_column.json
@@ -1,0 +1,17 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "bbb",
+        " b ",
+        "bbb"
+    ],
+    "key": {
+        "b": {
+            "item": "breadcrumbs:bread_block"
+        }
+    },
+    "result": {
+        "item": "breadcrumbs:bread_column",
+        "count": 6
+    }
+}

--- a/src/main/resources/data/breadcrumbs/recipes/bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/bread_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/recipes/bread_column_from_stonecutting.json
@@ -1,0 +1,8 @@
+{
+    "type": "minecraft:stonecutting",
+    "ingredient": {
+        "item": "breadcrumbs:bread_block"
+    },
+    "result": "breadcrumbs:bread_column",
+    "count": 1
+}

--- a/src/main/resources/data/breadcrumbs/recipes/bread_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/bread_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/honey_bread_brick_column.json
+++ b/src/main/resources/data/breadcrumbs/recipes/honey_bread_brick_column.json
@@ -1,0 +1,17 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "hhh",
+        " h ",
+        "hhh"
+    ],
+    "key": {
+        "h": {
+            "item": "breadcrumbs:honey_bread_bricks"
+        }
+    },
+    "result": {
+        "item": "breadcrumbs:honey_bread_brick_column",
+        "count": 6
+    }
+}

--- a/src/main/resources/data/breadcrumbs/recipes/honey_bread_brick_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/honey_bread_brick_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/honey_bread_brick_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/recipes/honey_bread_brick_column_from_stonecutting.json
@@ -1,0 +1,8 @@
+{
+    "type": "minecraft:stonecutting",
+    "ingredient": {
+        "item": "breadcrumbs:honey_bread_bricks"
+    },
+    "result": "breadcrumbs:honey_bread_brick_column",
+    "count": 1
+}

--- a/src/main/resources/data/breadcrumbs/recipes/honey_bread_brick_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/honey_bread_brick_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/honey_bread_column.json
+++ b/src/main/resources/data/breadcrumbs/recipes/honey_bread_column.json
@@ -1,0 +1,17 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "bbb",
+        " b ",
+        "bbb"
+    ],
+    "key": {
+        "b": {
+            "item": "breadcrumbs:honey_bread_block"
+        }
+    },
+    "result": {
+        "item": "breadcrumbs:honey_bread_column",
+        "count": 6
+    }
+}

--- a/src/main/resources/data/breadcrumbs/recipes/honey_bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/honey_bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/honey_bread_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/recipes/honey_bread_column_from_stonecutting.json
@@ -1,0 +1,8 @@
+{
+    "type": "minecraft:stonecutting",
+    "ingredient": {
+        "item": "breadcrumbs:honey_bread_block"
+    },
+    "result": "breadcrumbs:honey_bread_column",
+    "count": 1
+}

--- a/src/main/resources/data/breadcrumbs/recipes/honey_bread_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/honey_bread_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/polished_bread_column.json
+++ b/src/main/resources/data/breadcrumbs/recipes/polished_bread_column.json
@@ -1,0 +1,17 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "bbb",
+        " b ",
+        "bbb"
+    ],
+    "key": {
+        "b": {
+            "item": "breadcrumbs:polished_bread_block"
+        }
+    },
+    "result": {
+        "item": "breadcrumbs:polished_bread_column",
+        "count": 6
+    }
+}

--- a/src/main/resources/data/breadcrumbs/recipes/polished_bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/polished_bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/polished_bread_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/recipes/polished_bread_column_from_stonecutting.json
@@ -1,0 +1,8 @@
+{
+    "type": "minecraft:stonecutting",
+    "ingredient": {
+        "item": "breadcrumbs:polished_bread_block"
+    },
+    "result": "breadcrumbs:polished_bread_column",
+    "count": 1
+}

--- a/src/main/resources/data/breadcrumbs/recipes/polished_bread_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/polished_bread_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/polished_honey_bread_column.json
+++ b/src/main/resources/data/breadcrumbs/recipes/polished_honey_bread_column.json
@@ -1,0 +1,17 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "bbb",
+        " b ",
+        "bbb"
+    ],
+    "key": {
+        "b": {
+            "item": "breadcrumbs:polished_honey_bread_block"
+        }
+    },
+    "result": {
+        "item": "breadcrumbs:polished_honey_bread_column",
+        "count": 6
+    }
+}

--- a/src/main/resources/data/breadcrumbs/recipes/polished_honey_bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/polished_honey_bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/polished_honey_bread_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/recipes/polished_honey_bread_column_from_stonecutting.json
@@ -1,0 +1,8 @@
+{
+    "type": "minecraft:stonecutting",
+    "ingredient": {
+        "item": "breadcrumbs:polished_honey_bread_block"
+    },
+    "result": "breadcrumbs:polished_honey_bread_column",
+    "count": 1
+}

--- a/src/main/resources/data/breadcrumbs/recipes/polished_honey_bread_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/polished_honey_bread_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/polished_pumpkin_bread_column.json
+++ b/src/main/resources/data/breadcrumbs/recipes/polished_pumpkin_bread_column.json
@@ -1,0 +1,17 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "bbb",
+        " b ",
+        "bbb"
+    ],
+    "key": {
+        "b": {
+            "item": "breadcrumbs:polished_pumpkin_bread_block"
+        }
+    },
+    "result": {
+        "item": "breadcrumbs:polished_pumpkin_bread_column",
+        "count": 6
+    }
+}

--- a/src/main/resources/data/breadcrumbs/recipes/polished_pumpkin_bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/polished_pumpkin_bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/polished_pumpkin_bread_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/recipes/polished_pumpkin_bread_column_from_stonecutting.json
@@ -1,0 +1,8 @@
+{
+    "type": "minecraft:stonecutting",
+    "ingredient": {
+        "item": "breadcrumbs:polished_pumpkin_bread_block"
+    },
+    "result": "breadcrumbs:polished_pumpkin_bread_column",
+    "count": 1
+}

--- a/src/main/resources/data/breadcrumbs/recipes/polished_pumpkin_bread_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/polished_pumpkin_bread_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_brick_column.json
+++ b/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_brick_column.json
@@ -1,0 +1,17 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "ppp",
+        " p ",
+        "ppp"
+    ],
+    "key": {
+        "p": {
+            "item": "breadcrumbs:pumpkin_bread_bricks"
+        }
+    },
+    "result": {
+        "item": "breadcrumbs:pumpkin_bread_brick_column",
+        "count": 6
+    }
+}

--- a/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_brick_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_brick_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_brick_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_brick_column_from_stonecutting.json
@@ -1,0 +1,8 @@
+{
+    "type": "minecraft:stonecutting",
+    "ingredient": {
+        "item": "breadcrumbs:pumpkin_bread_bricks"
+    },
+    "result": "breadcrumbs:pumpkin_bread_brick_column",
+    "count": 1
+}

--- a/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_brick_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_brick_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_column.json
+++ b/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_column.json
@@ -1,0 +1,17 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "bbb",
+        " b ",
+        "bbb"
+    ],
+    "key": {
+        "b": {
+            "item": "breadcrumbs:pumpkin_bread_block"
+        }
+    },
+    "result": {
+        "item": "breadcrumbs:pumpkin_bread_column",
+        "count": 6
+    }
+}

--- a/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_column.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_column.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_column_from_stonecutting.json
+++ b/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_column_from_stonecutting.json
@@ -1,0 +1,8 @@
+{
+    "type": "minecraft:stonecutting",
+    "ingredient": {
+        "item": "breadcrumbs:pumpkin_bread_block"
+    },
+    "result": "breadcrumbs:pumpkin_bread_column",
+    "count": 1
+}

--- a/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_column_from_stonecutting.json.mcmeta
+++ b/src/main/resources/data/breadcrumbs/recipes/pumpkin_bread_column_from_stonecutting.json.mcmeta
@@ -1,0 +1,7 @@
+{
+    "when": [
+        {
+            "libcd:mod_loaded": "columns"
+        }
+    ]
+}

--- a/src/main/resources/data/columns/tags/blocks/columns.json
+++ b/src/main/resources/data/columns/tags/blocks/columns.json
@@ -14,6 +14,7 @@
                     "breadcrumbs:polished_bread_column",
                     "breadcrumbs:polished_honey_bread_column",
                     "breadcrumbs:polished_pumpkin_bread_column",
+                    "breadcrumbs:pumpkin_bread_brick_column",
                     "breadcrumbs:pumpkin_bread_column"
                 ]
             }

--- a/src/main/resources/data/columns/tags/blocks/columns.json
+++ b/src/main/resources/data/columns/tags/blocks/columns.json
@@ -10,7 +10,8 @@
                     "breadcrumbs:bread_brick_column",
                     "breadcrumbs:bread_column",
                     "breadcrumbs:honey_bread_column",
-                    "breadcrumbs:polished_bread_column"
+                    "breadcrumbs:polished_bread_column",
+                    "breadcrumbs:polished_honey_bread_column"
                 ]
             }
         ]

--- a/src/main/resources/data/columns/tags/blocks/columns.json
+++ b/src/main/resources/data/columns/tags/blocks/columns.json
@@ -12,7 +12,8 @@
                     "breadcrumbs:honey_bread_brick_column",
                     "breadcrumbs:honey_bread_column",
                     "breadcrumbs:polished_bread_column",
-                    "breadcrumbs:polished_honey_bread_column"
+                    "breadcrumbs:polished_honey_bread_column",
+                    "breadcrumbs:pumpkin_bread_column"
                 ]
             }
         ]

--- a/src/main/resources/data/columns/tags/blocks/columns.json
+++ b/src/main/resources/data/columns/tags/blocks/columns.json
@@ -7,6 +7,7 @@
                     "libcd:mod_loaded": "columns"
                 },
                 "values": [
+                    "breadcrumbs:bread_brick_column",
                     "breadcrumbs:bread_column",
                     "breadcrumbs:polished_bread_column"
                 ]

--- a/src/main/resources/data/columns/tags/blocks/columns.json
+++ b/src/main/resources/data/columns/tags/blocks/columns.json
@@ -13,6 +13,7 @@
                     "breadcrumbs:honey_bread_column",
                     "breadcrumbs:polished_bread_column",
                     "breadcrumbs:polished_honey_bread_column",
+                    "breadcrumbs:polished_pumpkin_bread_column",
                     "breadcrumbs:pumpkin_bread_column"
                 ]
             }

--- a/src/main/resources/data/columns/tags/blocks/columns.json
+++ b/src/main/resources/data/columns/tags/blocks/columns.json
@@ -9,6 +9,7 @@
                 "values": [
                     "breadcrumbs:bread_brick_column",
                     "breadcrumbs:bread_column",
+                    "breadcrumbs:honey_bread_brick_column",
                     "breadcrumbs:honey_bread_column",
                     "breadcrumbs:polished_bread_column",
                     "breadcrumbs:polished_honey_bread_column"

--- a/src/main/resources/data/columns/tags/blocks/columns.json
+++ b/src/main/resources/data/columns/tags/blocks/columns.json
@@ -1,0 +1,15 @@
+{
+    "values": [],
+    "libcd": {
+        "entries": [
+            {
+                "when": {
+                    "libcd:mod_loaded": "columns"
+                },
+                "values": [
+                    "breadcrumbs:bread_column"
+                ]
+            }
+        ]
+    }
+}

--- a/src/main/resources/data/columns/tags/blocks/columns.json
+++ b/src/main/resources/data/columns/tags/blocks/columns.json
@@ -9,6 +9,7 @@
                 "values": [
                     "breadcrumbs:bread_brick_column",
                     "breadcrumbs:bread_column",
+                    "breadcrumbs:honey_bread_column",
                     "breadcrumbs:polished_bread_column"
                 ]
             }

--- a/src/main/resources/data/columns/tags/blocks/columns.json
+++ b/src/main/resources/data/columns/tags/blocks/columns.json
@@ -7,7 +7,8 @@
                     "libcd:mod_loaded": "columns"
                 },
                 "values": [
-                    "breadcrumbs:bread_column"
+                    "breadcrumbs:bread_column",
+                    "breadcrumbs:polished_bread_column"
                 ]
             }
         ]

--- a/src/main/resources/data/columns/tags/items/columns.json
+++ b/src/main/resources/data/columns/tags/items/columns.json
@@ -14,6 +14,7 @@
                     "breadcrumbs:polished_bread_column",
                     "breadcrumbs:polished_honey_bread_column",
                     "breadcrumbs:polished_pumpkin_bread_column",
+                    "breadcrumbs:pumpkin_bread_brick_column",
                     "breadcrumbs:pumpkin_bread_column"
                 ]
             }

--- a/src/main/resources/data/columns/tags/items/columns.json
+++ b/src/main/resources/data/columns/tags/items/columns.json
@@ -10,7 +10,8 @@
                     "breadcrumbs:bread_brick_column",
                     "breadcrumbs:bread_column",
                     "breadcrumbs:honey_bread_column",
-                    "breadcrumbs:polished_bread_column"
+                    "breadcrumbs:polished_bread_column",
+                    "breadcrumbs:polished_honey_bread_column"
                 ]
             }
         ]

--- a/src/main/resources/data/columns/tags/items/columns.json
+++ b/src/main/resources/data/columns/tags/items/columns.json
@@ -12,7 +12,8 @@
                     "breadcrumbs:honey_bread_brick_column",
                     "breadcrumbs:honey_bread_column",
                     "breadcrumbs:polished_bread_column",
-                    "breadcrumbs:polished_honey_bread_column"
+                    "breadcrumbs:polished_honey_bread_column",
+                    "breadcrumbs:pumpkin_bread_column"
                 ]
             }
         ]

--- a/src/main/resources/data/columns/tags/items/columns.json
+++ b/src/main/resources/data/columns/tags/items/columns.json
@@ -7,6 +7,7 @@
                     "libcd:mod_loaded": "columns"
                 },
                 "values": [
+                    "breadcrumbs:bread_brick_column",
                     "breadcrumbs:bread_column",
                     "breadcrumbs:polished_bread_column"
                 ]

--- a/src/main/resources/data/columns/tags/items/columns.json
+++ b/src/main/resources/data/columns/tags/items/columns.json
@@ -13,6 +13,7 @@
                     "breadcrumbs:honey_bread_column",
                     "breadcrumbs:polished_bread_column",
                     "breadcrumbs:polished_honey_bread_column",
+                    "breadcrumbs:polished_pumpkin_bread_column",
                     "breadcrumbs:pumpkin_bread_column"
                 ]
             }

--- a/src/main/resources/data/columns/tags/items/columns.json
+++ b/src/main/resources/data/columns/tags/items/columns.json
@@ -9,6 +9,7 @@
                 "values": [
                     "breadcrumbs:bread_brick_column",
                     "breadcrumbs:bread_column",
+                    "breadcrumbs:honey_bread_brick_column",
                     "breadcrumbs:honey_bread_column",
                     "breadcrumbs:polished_bread_column",
                     "breadcrumbs:polished_honey_bread_column"

--- a/src/main/resources/data/columns/tags/items/columns.json
+++ b/src/main/resources/data/columns/tags/items/columns.json
@@ -1,0 +1,15 @@
+{
+    "values": [],
+    "libcd": {
+        "entries": [
+            {
+                "when": {
+                    "libcd:mod_loaded": "columns"
+                },
+                "values": [
+                    "breadcrumbs:bread_column"
+                ]
+            }
+        ]
+    }
+}

--- a/src/main/resources/data/columns/tags/items/columns.json
+++ b/src/main/resources/data/columns/tags/items/columns.json
@@ -9,6 +9,7 @@
                 "values": [
                     "breadcrumbs:bread_brick_column",
                     "breadcrumbs:bread_column",
+                    "breadcrumbs:honey_bread_column",
                     "breadcrumbs:polished_bread_column"
                 ]
             }

--- a/src/main/resources/data/columns/tags/items/columns.json
+++ b/src/main/resources/data/columns/tags/items/columns.json
@@ -7,7 +7,8 @@
                     "libcd:mod_loaded": "columns"
                 },
                 "values": [
-                    "breadcrumbs:bread_column"
+                    "breadcrumbs:bread_column",
+                    "breadcrumbs:polished_bread_column"
                 ]
             }
         ]

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,9 +33,11 @@
   "depends": {
     "fabricloader": ">=0.7.4",
     "fabric": "*",
-    "minecraft": "1.16.x"
+    "minecraft": "1.16.x",
+    "libcd": "*"
   },
   "suggests": {
-    "flamingo": "*"
+    "flamingo": "*",
+    "columns": "*"
   }
 }


### PR DESCRIPTION
This pull request adds columns for all Breadcrumbs blocks with a wall variant. These column blocks are only registered while the [Columns](https://github.com/haykam821/Columns) mod is loaded.

![All bread columns](https://user-images.githubusercontent.com/24855774/118308715-489b8300-b4ba-11eb-86c2-7bc50f870ada.png)
